### PR TITLE
reduces depth of cnn so that it fits properly

### DIFF
--- a/Loss_plots/generate_data/classical_loss.py
+++ b/Loss_plots/generate_data/classical_loss.py
@@ -28,7 +28,7 @@ def create_rand_params(h):
     if type(h) == nn.Linear:
         h.weight.data.uniform_(0, 1)
 
-nnsize = [4,1,1,1,2]
+nnsize = [4,2]
 from sklearn import datasets
 iris = datasets.load_iris()
 x, Y = iris.data, iris.target


### PR DESCRIPTION

In the paper, you claim a training advantage of Quantum NN over classical NN.
In section 4.2 Fig 3b, we see that the classical neural network has a much larger loss than the quantum network.

The other alternative is to use a classical net that is less deep, see this PR.
Here, loss is much better for the classical nnet.

The core of the issue is that you have a training issue in your classical net. (The reason is that your classical net is too deep for such a simple problem, which is why you run into this problem.)

I don't think the model you present in this paper supports your conclusion. In particular, in the conclusion you claim that "Overall, we have shown that quantum neural networks [...]to train faster [...]."